### PR TITLE
fix typing issue when using branch 2.x with nodalflow-2.x together

### DIFF
--- a/src/Extractors/DbExtractorAbstract.php
+++ b/src/Extractors/DbExtractorAbstract.php
@@ -90,7 +90,7 @@ abstract class DbExtractorAbstract extends ExtractorBatchLimitAbstract
      *
      * @return \Generator
      */
-    public function getTraversable($param = null)
+    public function getTraversable($param = null): iterable
     {
         /*
          * unfortunately, we can't do something a simple as


### PR DESCRIPTION
fixes:
Symfony\Component\Debug\Exception\FatalErrorException  : Declaration of fab2s\YaEtl\Extractors\DbExtractorAbstract::getTraversable($param = NULL) must be compatible with fab2s\NodalFlow\Nodes\TraversableNodeInterface::getTraversable($param = NULL): iterable